### PR TITLE
CaveWhere.pro : Run protoc from the path.

### DIFF
--- a/Cavewhere.pro
+++ b/Cavewhere.pro
@@ -486,7 +486,7 @@ PROTO_FILES += \
     src/qt.proto
 
 unix {
-    PROTOC = /usr/local/bin/protoc
+    PROTOC = protoc
 }
 
 win32 {


### PR DESCRIPTION
On Fedora 20, protobuf is available as an rmp and the protoc program
is installed in /usr/bin. I suspect this is true for other distros
also.

Signed-off-by: Philip Balister philip@balister.org
