### PR TITLE
change station renaming algorithm

### DIFF
--- a/src/cwCompassImporter.cpp
+++ b/src/cwCompassImporter.cpp
@@ -44,16 +44,12 @@ void cwCompassImporter::runTask()
         CurrentFileGood = true;
         CurrentTrip = nullptr;
         LineCount = 0;
-        StationRenamer.setCave(CurrentCave);
 
         //Make sure file is good
         verifyCompassDataFileExists();
 
         //Parse the current file
         parseFile();
-
-        //Fix invalid station names
-        StationRenamer.renameInvalidStations();
 
         if(!CurrentFileGood) {
             //Parsing error in the last cave, remove it from list
@@ -311,7 +307,7 @@ void cwCompassImporter::parseSurveyTeam(QFile *file)
     }
 
     QString surveyTeam = file->readLine();
-    surveyTeam = surveyTeamLabel.trimmed();
+    surveyTeam = surveyTeam.trimmed();
 
     LineCount++;
     if(!isFileGood(file, "survey team")) { return; }
@@ -323,7 +319,14 @@ void cwCompassImporter::parseSurveyTeam(QFile *file)
         surveyTeam.resize(100);
     }
 
-    QStringList teamList = surveyTeam.split(" ", QString::SkipEmptyParts);
+    QRegExp delimiter;
+    if (surveyTeam.contains(';')) {
+        delimiter = QRegExp("\\s*;\\s*");
+    } else {
+        delimiter = QRegExp("\\s\\s+|\\s*,\\s*");
+    }
+
+    QStringList teamList = surveyTeam.split(delimiter, QString::SkipEmptyParts);
     if(!teamList.isEmpty()) {
         cwTeam* team = new cwTeam();
 

--- a/src/cwStationRenamer.h
+++ b/src/cwStationRenamer.h
@@ -10,13 +10,12 @@
 #define CWSTATIONRENAMER_H
 
 //Our includes
-class cwCave;
-class cwSurveyChunk;
 #include "cwStation.h"
 
 //Qt includes
 #include <QString>
-#include <QPointer>
+#include <QHash>
+#include <QSet>
 
 /**
  * @brief The cwStationRenamer class
@@ -29,12 +28,7 @@ class cwStationRenamer
 public:
     cwStationRenamer();
 
-    void setCave(cwCave* cave);
-    cwCave* cave() const;
-
     cwStation createStation(QString stationName);
-
-    void renameInvalidStations();
 
     void clear();
 
@@ -43,11 +37,8 @@ private:
     QHash<QString, QString> ValidToInvalidStations;
     QSet<QString> ValidStations;
 
-    QPointer<cwCave> Cave;
-
-    void renameInvalidStationsInChunk(cwSurveyChunk* chunk,
-                                      int stationIndex,
-                                      const QRegExp& removeInvalidCharsRegex);
+    static const QRegExp validUcaseRx;
+    static const QRegExp invalidCharRx;
 };
 
 #endif // CWSTATIONRENAMER_H


### PR DESCRIPTION
This would change the station renaming to the following:

* Lowercase chars get replaced with uppercase + `-`.  E.g. `ld40` -> `L-D-40`.  This ensures that:
  * stations with different case but same number in Compass and Walls (which are case sensitive) would not be considered the same
  * if we inform the users about this transformation, they can easily figure out what the station name was in the original data
* Invalid chars get replaced with `_`
* If transformed name already exists, it tries the name with `_1` on the end, then tries `_2`, counting up until it finds a unique station.

Note that I simplified `cwStationRenamer` by getting rid of UUID usage and `renameInvalidStations` and just making `createStation` go ahead and generate the final transformed name on the spot.  (Was there a particular reason for using UUIDs at first and then renaming at the end?  Performance or anything?  It seemed unnecessary to me)