### PR TITLE
make used station grouping more flexible

### DIFF
--- a/src/cwUsedStationsTask.cpp
+++ b/src/cwUsedStationsTask.cpp
@@ -68,17 +68,11 @@ void cwUsedStationsTask::runTask() {
   This is a threaded helper function to createSplitStationNames
   */
 cwUsedStationsTask::SplitStationName cwUsedStationsTask::splitName(cwStation station) {
-    QRegExp splitStationsReg("((?:[a-z]|[A-Z])*)(\\d*\\w*)");
-    if(splitStationsReg.exactMatch(station.name())) {
-        QString surveyName = splitStationsReg.cap(1).toUpper();
-        QString stationName = splitStationsReg.cap(2);
-
-        cwUsedStationsTask::SplitStationName splitStation(surveyName, stationName);
-        return splitStation;
-    } else {
-        qDebug() << "Can't match: " << station.name() << LOCATION;
-    }
-    return cwUsedStationsTask::SplitStationName();
+    QRegExp namePartRegExp("\\d+\\D*$");
+    int index = std::max(namePartRegExp.indexIn(station.name()), 0);
+    QString surveyName = station.name().left(index).toUpper();
+    QString stationName = station.name().mid(index);
+    return cwUsedStationsTask::SplitStationName(surveyName, stationName);
 }
 
 /**


### PR DESCRIPTION
This makes `cwUsedStationsTask` able to group stations more flexibly.  It takes as the "station name" the last string of digits optionally followed by non-digits.  This means anything can come before the last string of digits, including other numbers.  I've heard of some projects (mostly in Europe I think?) using numbers for the survey designation, e.g. 1.1, 1.2, 1.3, etc.

Assuming these would get imported as 1_1, 1_2, 1_3, and so forth, with this change cavewhere would show: **1_** Survey, Stations **1** to **3**.

With this I could also rework `cwStationRenamer` to put the disambiguating number in the middle instead of at the end, so that it wouldn't inhibit station grouping.

Note: we could make it strip the trailing _ and - off of the survey name, so that that would just be **1** Survey, Stations **1** to **3**.