### PR TITLE
make cwStationRenamer put the disambiguating number before the last n…

### DIFF
--- a/src/cwStationRenamer.cpp
+++ b/src/cwStationRenamer.cpp
@@ -20,10 +20,11 @@ const QRegExp cwStationRenamer::InvalidCharRegExp("[^-_a-zA-Z0-9]");
  * @param originalName the name of the station in the original data (e.g.
  * Compass or Walls import)
  * @return a cwStation with originalName if it is valid, and otherwise with all
- * invalid chars in originalName replaced with _ and a _1, _2, etc. at the end
- * if necessary to disambiguate.  Since input formats are case-sensitive but
- * Cavewhere is not, if for instance the data contain LD40 and ld40, one will be
- * given a number suffix so that Cavewhere doesn't consider them the same.
+ * invalid chars in originalName replaced with _ and a -1, -2, etc. at the end
+ * or -1-, -2-, etc. before the number if necessary to disambiguate.
+ * Since input formats are case-sensitive but Cavewhere is not, if for instance
+ * the data contain LD40 and ld40, one will be given a disambiguating number
+ * infix or suffix so that Cavewhere doesn't consider them the same.
  * So for example, with the following stations:
  *   LD40
  *   ld40
@@ -32,10 +33,10 @@ const QRegExp cwStationRenamer::InvalidCharRegExp("[^-_a-zA-Z0-9]");
  *   FR:w%B
  * The created station names would be:
  *   LD40
- *   ld40_1
+ *   ld-1-40
  *   FR_W_B
- *   FR_W_B_1
- *   FR_w_B_2
+ *   FR_W_B-1
+ *   FR_w_B-2
  */
 cwStation cwStationRenamer::createStation(QString originalName)
 {
@@ -48,13 +49,27 @@ cwStation cwStationRenamer::createStation(QString originalName)
         // e.g. FR:WB$ -> FR_WB_
         newName.replace(InvalidCharRegExp, "_");
 
-        // if uppercase of new name already exists try adding _1, _2, etc.
-        // until that doesn't exist
+        // if uppercase of new name already exists, add something in to disambiguate
         if (UpperCaseRenamedStations.contains(newName.toUpper())) {
+            QRegExp namePartRegExp("\\d+\\D*$");
+
+            // determine where to insert the disambiguating number.
+            // if there are digits in the name, we will insert the disambiguating number
+            // before the last string of digits.  Otherwise, we'll append it to the end
+            int insertIndex = namePartRegExp.indexIn(newName);
+            if (insertIndex < 0) insertIndex = newName.length();
+            QString prefix = newName.left(insertIndex);
+            QString suffix = newName.mid(insertIndex);
+
             int num = 1;
             QString numberedName;
             do {
-                numberedName = QString("%1_%2").arg(newName).arg(num);
+                if (suffix.length()) {
+                    numberedName = QString("%1-%2-%3").arg(prefix).arg(num).arg(suffix);
+                }
+                else {
+                    numberedName = QString("%1-%2").arg(prefix).arg(num);
+                }
             } while (UpperCaseRenamedStations.contains(numberedName.toUpper()));
             newName = numberedName;
         }


### PR DESCRIPTION
…umber in the station name, if possible.

So for instance in Fisher Ridge, there's an MNE and an MNe survey.  So MNe1 and MNe2 get transformed to MNe-1-1, MNe-1-2, etc.  That way if my PR for used station grouping changes is merged also, these would get grouped as **MNe-1-** Survey, Stations **1** to **2**.

If there's no number at the end, for instance if there is an ABC and later an abc, the latter would just get renamed to abc-1.