### PR TITLE
Fix QPainterPath build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ qbs setup-qt /opt/qt514/bin/qmake qt5
 qbs config profiles.qt5.baseProfile x86_64-linux-gnu-gcc-7
 qbs config defaultProfile qt5
 qbs resolve profile:qt5 config:release
-qbs build --products profile:qt5 config:release
+qbs build --products CaveWhere profile:qt5 config:release
 ```
 
 ### Running CaveWhere

--- a/src/cwNorthArrowItem.cpp
+++ b/src/cwNorthArrowItem.cpp
@@ -14,6 +14,7 @@
 
 //Qt includes
 #include <QPen>
+#include <QPainterPath>
 
 cwNorthArrowItem::cwNorthArrowItem(QQuickItem *parent) :
     cwAbstract2PointItem(parent),

--- a/src/cwScaleLengthItem.cpp
+++ b/src/cwScaleLengthItem.cpp
@@ -12,6 +12,7 @@
 
 //Qt includes
 #include <QDebug>
+#include <QPainterPath>
 
 cwScaleLengthItem::cwScaleLengthItem(QQuickItem *parent) :
     cwAbstract2PointItem(parent),


### PR DESCRIPTION
readme fix, plus fix parallel to thestr4ng3r/chiaki#253 (based on quick googling of error) to get build on Arch Linux, qbs 1.16, qt 5.15.0, gcc 10.1.0

error from tests:
```
/home/eric/programs/cavewhere/testcases/test_CavewhereMainWindow.cpp:98: FAILED:
  CHECK( mainWindow2->property("x").toInt() == 323 )
with expansion:
  2974 (0xb9e) == 323 (0x143)
```

and a lot of noise about QML, e.g. `file:///home/eric/programs/cavewhere/src/../qml/SaveFeedbackHelpBox.qml:22:5: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }` and `file:///home/eric/programs/cavewhere/qml/MainSideBar.qml:160: TypeError: Cannot read property 'left' of null`

and reported leaks:
```
==3408721==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 864 byte(s) in 6 object(s) allocated from:
    #0 0x7f9824d2ef41 in operator new(unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x7f98218d1204 in QQmlData::createQQmlData(QObjectPrivate*) (/usr/lib/libQt5Qml.so.5+0x25e204)

Indirect leak of 816 byte(s) in 6 object(s) allocated from:
    #0 0x7f9824d2f0c1 in operator new[](unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:102
    #1 0x7f9820914f04 in QHashData::rehash(int) (/usr/lib/libQt5Core.so.5+0x109f04)

Indirect leak of 288 byte(s) in 6 object(s) allocated from:
    #0 0x7f9824d2ef41 in operator new(unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x7f9820914d47 in QHashData::detach_helper(void (*)(QHashData::Node*, void*), void (*)(QHashData::Node*), int, int) (/usr/lib/libQt5Core.so.5+0x109d47)

Indirect leak of 192 byte(s) in 6 object(s) allocated from:
    #0 0x7f9824d2d459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f9820914b38 in QHashData::allocateNode(int) (/usr/lib/libQt5Core.so.5+0x109b38)

Indirect leak of 48 byte(s) in 6 object(s) allocated from:
    #0 0x7f9824d2ef41 in operator new(unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x7f98218d0e4e in QQmlData::attachedProperties() const (/usr/lib/libQt5Qml.so.5+0x25de4e)

SUMMARY: AddressSanitizer: 2208 byte(s) leaked in 30 allocation(s).
```